### PR TITLE
Update HOST with Apple production API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ Client using .p12 and passphrase
 const APNS = require('apns-http2');
 const fs = require('fs');
 const apnsClient = new APNS({
-	pfx: fs.readFileSync('/path/to/Certificates.p12'),
+    pfx: fs.readFileSync('/path/to/Certificates.p12'),
     passphrase: 'test',
-    apns_topic: 'com.yourapp.com'
+    apns_topic: 'com.yourapp.com',
+    production: false
 });
 ```
 
@@ -25,9 +26,10 @@ Client using cert and key in .pem extension
 const APNS = require('apns-http2');
 const fs = require('fs');
 const apnsClient = new APNS({
-	cert: fs.readFileSync('/path/to/Certificate.pem'),
+    cert: fs.readFileSync('/path/to/Certificate.pem'),
     key: fs.readFileSync('/path/to/key.pem'),
-    apns_topic: 'com.yourapp.com'
+    apns_topic: 'com.yourapp.com',
+    production: false
 });
 ```
 ### Sending Push Notification
@@ -45,17 +47,18 @@ const alert = {
         };
 const deviceToken = '00fc13adff785122b4ad28809a3420982341241421348097878e577c991de8f0';
 const options = {
-	'aps' : aps,
-	'alert' : alert,
-	'priority' : 10,
-	'expiration' : 0
+    'aps' : aps,
+    'alert' : alert,
+    'priority' : 10,
+    'expiration' : 0
 }
 const notification = new Notification(deviceToken, options);
 apnsClient.send(notification)
 .then((res) => {
-	console.log("response  " + res);
+    console.log("response:  ");
+    console.dir(res);
 }).catch((err) => {
-	console.log('APNS ERROR: ' + err);
+    console.log('APNS ERROR: ' + err);
 });
 ```
 #### Payload Example can be found here [Notification JSON payload examples](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/TheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH107-SW10)

--- a/lib/apns-http2.js
+++ b/lib/apns-http2.js
@@ -8,7 +8,7 @@ const Notification = require('./notification.js');
  * @default
  * @desc Host i.e. server to connect
  */
-const HOST = 'api.development.push.apple.com';	
+const HOST = 'api.push.apple.com';	
 /**
  * @const
  * @type {Number}

--- a/lib/apns-http2.js
+++ b/lib/apns-http2.js
@@ -6,9 +6,10 @@ const Notification = require('./notification.js');
  * @const
  * @type {String}
  * @default
- * @desc Host i.e. server to connect
+ * @desc Hosts i.e. server to connect
  */
-const HOST = 'api.push.apple.com';	
+const PRD_HOST = 'api.push.apple.com';
+const DEV_HOST = 'api.development.push.apple.com';
 /**
  * @const
  * @type {Number}
@@ -25,67 +26,68 @@ const PORT =  443;
 const VERSION = 3;
 
 class APNSHTTP2  {
-	/**
-	 * @constructor 
-	 * @param {Object} options
-	 */
-	constructor(options) {
-    	this.key = options.key;
-   	 	this.cert = options.cert;
-    	this.pfx = options.pfx;
-    	this.passphrase = options.passphrase;
-    	this.apns_topic = options.apns_topic;
-    	this.client = new HTTP2Client(options.host || HOST, options.port || PORT);
-	}
-	/**
-	 * @static
-	 * @return {Class} Notification
-	 */
-	static Notification() {
-		return Notification;
-	}
-	/**
-	 * @param {Array<Notification> | Notification} notifications
-	 * @return {Array<Promises> | Promise}
-	 */
-	send(notifications) {
-		if (!Array.isArray(notifications)) {
-     		 return this._sendToApns(notifications);
-   		 }
+    /**
+     * @constructor 
+     * @param {Object} options
+     */
+    constructor(options) {
+        this.key = options.key;
+        this.cert = options.cert;
+        this.pfx = options.pfx;
+        this.passphrase = options.passphrase;
+        this.apns_topic = options.apns_topic;
+        this.host = options.production ? PRD_HOST : DEV_HOST
+        this.client = new HTTP2Client(options.host || this.host, options.port || PORT);
+    }
+    /**
+     * @static
+     * @return {Class} Notification
+     */
+    static Notification() {
+        return Notification;
+    }
+    /**
+     * @param {Array<Notification> | Notification} notifications
+     * @return {Array<Promises> | Promise}
+     */
+    send(notifications) {
+        if (!Array.isArray(notifications)) {
+              return this._sendToApns(notifications);
+            }
 
-   		 var promises =  notifications.map((notification) => this._sendToApns(notification).catch((err) => err));
-   		 return Promise.all(promises);
-	}
-	
-	_sendToApns(notification) {
-		if(!notification.deviceToken) return Promise.reject(new Error ("Device token missing"));
-		const options = {};
-		if (this.key) {
-			options.key = this.key;
-		}
-		if (this.cert) {
-			options.cert = this.cert;
-		}
-		if (this.pfx) {
-			options.pfx = this.pfx;
-		}
-		if (this.passphrase) {
-			options.passphrase = this.passphrase;
-		}
-		options.path = '/' + VERSION + '/device/'+notification.deviceToken;
-		options.method = 'POST';
-		options.headers = {};
-		if (this.apns_topic) {
-			options.headers['apns-topic'] = this.apns_topic; 
-		}
-		if (notification.priority) {
-			options.headers['apns-priority'] = notification.priority;
-		}
-		if (notification.expiration != undefined) {
-			options.headers['apns-expiration'] = notification.expiration;
-		}
-		return this.client.post(options, notification);
-	}
+            var promises =  notifications.map((notification) => this._sendToApns(notification).catch((err) => err));
+            return Promise.all(promises);
+    }
+    
+    _sendToApns(notification) {
+        if(!notification.deviceToken) return Promise.reject(new Error ("Device token missing"));
+        const options = {};
+        if (this.key) {
+            options.key = this.key;
+        }
+        if (this.cert) {
+            options.cert = this.cert;
+        }
+        if (this.pfx) {
+            options.pfx = this.pfx;
+        }
+        if (this.passphrase) {
+            options.passphrase = this.passphrase;
+        }
+        options.path = '/' + VERSION + '/device/'+notification.deviceToken;
+        options.method = 'POST';
+        options.headers = {};
+        if (this.apns_topic) {
+            options.headers['apns-topic'] = this.apns_topic; 
+        }
+        if (notification.priority) {
+            options.headers['apns-priority'] = notification.priority;
+        }
+        if (notification.expiration != undefined) {
+            options.headers['apns-expiration'] = notification.expiration;
+        }
+        return this.client.post(options, notification);
+    }
 }
 
 


### PR DESCRIPTION
When the certificate is only for production it does not work properly with this HOST so it's better to change to "api.push.apple.com" for production, or it's better to add boolean for production or development certificates